### PR TITLE
Section progress page renders with no error

### DIFF
--- a/crowdsourcer/templates/crowdsourcer/section_progress.html
+++ b/crowdsourcer/templates/crowdsourcer/section_progress.html
@@ -29,7 +29,7 @@
           {% for authority in authorities %}
             <tr>
                 <td>
-                    <a href="{% url url_pattern authority.name section.title %}">{{ authority.name }}</a> {% if authority.do_not_mark %}DO NOT MARK{% endif %}
+                    <a href="{% url 'authority_progress' authority.name %}">{{ authority.name }}</a> {% if authority.do_not_mark %}DO NOT MARK{% endif %}
                 </td>
                 <td>
                     <div class="progress progress-thin mb-2">


### PR DESCRIPTION
This is by changing the url that's pointed to for each authority