### PR TITLE
Link to council section audit from volunteer_progress when in audit phase

### DIFF
--- a/crowdsourcer/templates/crowdsourcer/volunteer_progress.html
+++ b/crowdsourcer/templates/crowdsourcer/volunteer_progress.html
@@ -33,7 +33,7 @@
           {% for authority in section.authorities %}
             <tr>
                 <td>
-                    <a href="{% url 'authority_question_edit' authority.name section.section.title %}">{{ authority.name }}</a>
+                    <a href="{% url authority_url_name authority.name section.section.title %}">{{ authority.name }}</a>
                 </td>
                 <td>
                     <div class="progress progress-thin mb-2">

--- a/crowdsourcer/views/progress.py
+++ b/crowdsourcer/views/progress.py
@@ -292,9 +292,15 @@ class VolunteerProgressView(UserPassesTestMixin, CurrentStageMixin, ListView):
                 }
             )
 
+        if self.current_stage.type == "First Mark":
+            authority_url_name = "authority_question_edit"
+        elif self.current_stage.type == "Audit":
+            authority_url_name = "authority_audit"
+
         context["user"] = user
         context["sections"] = progress
         context["page_title"] = "Volunteer Progress"
+        context["authority_url_name"] = authority_url_name
 
         return context
 


### PR DESCRIPTION
Previously, even when the audit phase was active, clicking a council’s name on the `/volunteer_progress/<userid>` page would take you to the first mark form for that authority+section, rather than the audit form for that authority+section.

We now alter the destination of the links on `/volunteer_progress/<userid>` based on the currently active mark phase.