### PR TITLE
Open audit form evidence links in a new window

### DIFF
--- a/crowdsourcer/templates/crowdsourcer/authority_audit_questions.html
+++ b/crowdsourcer/templates/crowdsourcer/authority_audit_questions.html
@@ -1,6 +1,7 @@
 {% extends 'crowdsourcer/base.html' %}
 
 {% load django_bootstrap5 %}
+{% load neighbourhood_filters %}
 
 {% block content %}
     <h1 class="mb-3 mb-md-4">
@@ -85,7 +86,7 @@
                   {% if q_form.question_obj.how_marked == 'foi' %}
                     <h4 class="form-label fs-6">FOI request</h4>
                     <div class="read-only-answer mb-3 mb-md-4">
-                        {{ q_form.orig.evidence|urlize }}
+                        {{ q_form.orig.evidence|urlize_external }}
                     </div>
                   {% else %}
                     <h4 class="form-label fs-6">Marker’s evidence of criteria met</h4>
@@ -97,7 +98,7 @@
                   {% if q_form.question_obj.how_marked != 'foi' %}
                     <h4 class="form-label fs-6">Links to evidence</h4>
                     <div class="read-only-answer mb-3 mb-md-4">
-                        {{ q_form.orig.public_notes|default:"(none)"|urlize|linebreaks }}
+                        {{ q_form.orig.public_notes|default:"(none)"|urlize_external|linebreaks }}
                     </div>
 
                     <h4 class="form-label fs-6">Page number</h4>

--- a/crowdsourcer/templatetags/neighbourhood_filters.py
+++ b/crowdsourcer/templatetags/neighbourhood_filters.py
@@ -1,0 +1,20 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+from django.utils.html import Urlizer
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+class UrlizerExternal(Urlizer):
+    url_template = '<a href="{href}" target="_blank" title="Opens in new window"{attrs}>{url}</a>'
+
+
+urlizer_external = UrlizerExternal()
+
+
+@register.filter(is_safe=True, needs_autoescape=True)
+@stringfilter
+def urlize_external(text, autoescape=True):
+    """Convert URLs in plain text into clickable links with target="_blank" etc"""
+    return mark_safe(urlizer_external(text, trim_url_limit=None, nofollow=True, autoescape=autoescape))


### PR DESCRIPTION
Required subclassing the built-in `Urlize` class, to override the link template string, and then using that in our own template filter.

Fixes #88.