### PR TITLE
Fix “Copy from First Mark” button for FOIs

### DIFF
--- a/crowdsourcer/templates/crowdsourcer/authority_audit_questions.html
+++ b/crowdsourcer/templates/crowdsourcer/authority_audit_questions.html
@@ -168,8 +168,13 @@
                       {% else %}
                         "option": "{{ q_form.orig.option.id }}",
                       {% endif %}
+                      {% if q_form.question_obj.how_marked == "foi" %}
+                        "evidence": "",
+                        "public_notes": "{{ q_form.orig.evidence|default_if_none:''|escapejs }}",
+                      {% else %}
                         "evidence": "{{ q_form.orig.evidence|default_if_none:''|escapejs }}",
                         "public_notes": "{{ q_form.orig.public_notes|default_if_none:''|escapejs }}",
+                      {% endif %}
                         "page_number": "{{ q_form.orig.page_number|default_if_none:''|escapejs }}",
                         "private_notes": "{{ q_form.orig.private_notes|default_if_none:''|escapejs }}"
                     }


### PR DESCRIPTION
FOI links were stored in the `evidence` field during First Mark, but CEUK want them transferred to the `public_notes` field during Audit (so that they are visible to the public).

This commit adds an exception for FOI questions, that redirects the content to the right fields, when you press the “Copy from First Mark” button on FOI questions.

Fixes #87.