### PR TITLE
Only link to non broken links on First Mark page

### DIFF
--- a/crowdsourcer/management/commands/process_broken_links.py
+++ b/crowdsourcer/management/commands/process_broken_links.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+
+import pandas as pd
+
+
+class Command(BaseCommand):
+    help = "create list of all broken evidence links"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--links",
+            action="store",
+            required=True,
+            help="CSV file with list of link response codes",
+        )
+
+    def handle(self, *args, **kwargs):
+        file = kwargs["links"]
+
+        df = pd.read_csv(file)
+        df = df.dropna(how="any")
+        df = df.loc[~df["status_code"].isin([200, 301, 302])]
+
+        df.to_csv("data/broken_links.csv")

--- a/crowdsourcer/models.py
+++ b/crowdsourcer/models.py
@@ -289,7 +289,7 @@ class Response(models.Model):
         text = self.public_notes
         if text is None:
             return []
-        links = re.findall(r"((?:https?://|www\.)[^ ]*)", text)
+        links = re.findall(r"((?:https?://|www\.)[^ \r\n]*)", text)
         return links
 
     @classmethod

--- a/crowdsourcer/templates/crowdsourcer/authority_questions_with_previous.html
+++ b/crowdsourcer/templates/crowdsourcer/authority_questions_with_previous.html
@@ -102,8 +102,15 @@
 
                   {% if q_form.question_obj.how_marked != 'foi' %}
                     <h4 class="form-label fs-6">Links to evidence</h4>
-                    <div class="read-only-answer mb-3 mb-md-4">
-                        {{ q_form.previous_response.public_notes|default:"(none)"|urlize_external|linebreaks }}
+                    <div class="read-only-answer mb-0 mb-md-0">
+                        {% for link in q_form.previous_response.evidence_links %}
+                          <p>
+                            {{ link|check_if_broken }}
+                          </p>
+                        {% endfor %}
+                    </div>
+                    <div class="text-muted mb-3 mb-md-4 small">
+                      Red links were found to be no longer available in an automated check.
                     </div>
 
                     <h4 class="form-label fs-6">Page number</h4>

--- a/crowdsourcer/templatetags/neighbourhood_filters.py
+++ b/crowdsourcer/templatetags/neighbourhood_filters.py
@@ -3,6 +3,8 @@ from django.template.defaultfilters import stringfilter
 from django.utils.html import Urlizer
 from django.utils.safestring import mark_safe
 
+from utils.data_checking import check_if_url_bad
+
 register = template.Library()
 
 
@@ -24,3 +26,12 @@ def urlize_external(text, autoescape=True):
             text, trim_url_limit=None, nofollow=True, autoescape=autoescape
         )
     )
+
+
+@register.filter(is_safe=True, needs_autoescape=True)
+@stringfilter
+def check_if_broken(text, autoescape=True):
+    if check_if_url_bad(text):
+        return mark_safe(f'<span class="text-danger">{text}</span>')
+    else:
+        return mark_safe(urlizer_external(text))

--- a/utils/data_checking.py
+++ b/utils/data_checking.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+
+import pandas as pd
+
+
+def get_bad_urls():
+    file = settings.BASE_DIR / "data" / "broken_links.csv"
+    if file.exists():
+        df = pd.read_csv(file)
+
+        links = df["url"]
+
+        return set(links)
+
+    return []
+
+
+def check_if_url_bad(url):
+    bad_urls = get_bad_urls()
+
+    if url in bad_urls:
+        return True
+
+    return False


### PR DESCRIPTION
Uses the list of link status codes provided by CEUK to generate a list of bad links and then uses that to only turn good URLs into links in the previous responses part of the first mark page.

Fixes #146