### PR TITLE
add config option to allow skipping questions on right of reply

### DIFF
--- a/crowdsourcer/middleware.py
+++ b/crowdsourcer/middleware.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.http import Http404
 
 from crowdsourcer.models import MarkingSession, ResponseType
 
@@ -21,6 +22,8 @@ class AddStateMiddleware:
             current_session = MarkingSession.objects.filter(
                 label=session_name, active=True
             ).first()
+            if current_session is None:
+                raise Http404
         else:
             current_session = (
                 MarkingSession.objects.filter(active=True).order_by("-default").first()

--- a/crowdsourcer/models.py
+++ b/crowdsourcer/models.py
@@ -261,6 +261,7 @@ class PublicAuthority(models.Model):
         ).annotate(
             num_questions=Subquery(
                 Question.objects.filter(
+                    id__in=questions,
                     questiongroup=OuterRef("questiongroup"),
                     section__title=section,
                     section__marking_session=marking_session,

--- a/crowdsourcer/views/base.py
+++ b/crowdsourcer/views/base.py
@@ -10,6 +10,7 @@ from django.db.models import Count, F, FloatField, OuterRef, Subquery
 from django.db.models.functions import Cast
 from django.dispatch import receiver
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 from django.views.generic import ListView, TemplateView
 
 from crowdsourcer.forms import ResponseForm, ResponseFormset
@@ -97,10 +98,14 @@ class BaseQuestionView(TemplateView):
         return initial
 
     def get_initial_obj(self):
-        self.authority = PublicAuthority.objects.get(name=self.kwargs["name"])
+        self.authority = get_object_or_404(PublicAuthority, name=self.kwargs["name"])
+        section = get_object_or_404(
+            Section,
+            title=self.kwargs["section_title"],
+            marking_session=self.request.current_session,
+        )
         self.questions = Question.objects.filter(
-            section__marking_session=self.request.current_session,
-            section__title=self.kwargs["section_title"],
+            section=section,
             questiongroup=self.authority.questiongroup,
             how_marked__in=self.how_marked_in,
         ).order_by("number", "number_part")

--- a/crowdsourcer/views/progress.py
+++ b/crowdsourcer/views/progress.py
@@ -129,10 +129,10 @@ class BaseAllAuthorityProgressView(UserPassesTestMixin, ListView):
 
         if self.request.current_session.entity_name is not None:
             self.page_title = (
-                f"{self.request.current_session.entity_name}s {self.page_title }"
+                f"{self.request.current_session.entity_name}s {self.page_title}"
             )
         else:
-            self.page_title = f"Councils {self.page_title }"
+            self.page_title = f"Councils {self.page_title}"
 
         context["councils"] = council_totals
         context["authorities"] = authorities

--- a/crowdsourcer/views/rightofreply.py
+++ b/crowdsourcer/views/rightofreply.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.views.generic import ListView
 
@@ -224,7 +224,8 @@ class AuthorityRORSectionQuestions(BaseQuestionView):
 
     def check_permissions(self):
         denied = True
-        authority = PublicAuthority.objects.get(name=self.kwargs["name"])
+        authority = get_object_or_404(PublicAuthority, name=self.kwargs["name"])
+
         user = self.request.user
 
         if user.is_anonymous:


### PR DESCRIPTION
This is initially for WhoFundsThem so MPs only need to response to things where they have an entry in the register. If "right_of_reply_responses_to_ignore" is set as a session config then any response that matches the list, plus blank responses, will not be displayed on the right of reply question screen.

The config should be a JSON array with the text descriptions.

For multi option values it will skip only if all selected values are in the list.

Also updates the section page questions counts to reflect this