### PR TITLE
Improvements to volunteer import script

### DIFF
--- a/crowdsourcer/tests/data/volunteers_with_council_restriction.csv
+++ b/crowdsourcer/tests/data/volunteers_with_council_restriction.csv
@@ -1,0 +1,2 @@
+First name,Last name,Email,Council Area,Type of Volunteering,Assigned Section,Nations/London
+First,Last,first_last@example.org,Aberdeenshire Council,Scorecards Volunteering,Transport,"England,London"

--- a/crowdsourcer/tests/data/volunteers_with_limit.csv
+++ b/crowdsourcer/tests/data/volunteers_with_limit.csv
@@ -1,0 +1,2 @@
+First name,Last name,Email,Council Area,Type of Volunteering,Assigned Section,How many sections?
+First,Last,first_last@example.org,Aberdeenshire Council,Scorecards Volunteering,Transport,3

--- a/crowdsourcer/tests/test_import_volunteers_script.py
+++ b/crowdsourcer/tests/test_import_volunteers_script.py
@@ -51,7 +51,11 @@ class AssignVolunteers(BaseCommandTestCase):
         ms = MarkingSession.objects.get(label="Default")
         for council in councils:
             a = PublicAuthority.objects.create(
-                name=council[0], unique_id=council[1], type="DIS", questiongroup_id=2
+                name=council[0],
+                country="england",
+                unique_id=council[1],
+                type="DIS",
+                questiongroup_id=2,
             )
             a.marking_session.set([ms])
 
@@ -118,6 +122,24 @@ class AssignVolunteers(BaseCommandTestCase):
         self.assertTrue("Aberdeenshire Council" not in councils)
         self.assertTrue("Aberdeen City Council" in councils)
         self.assertTrue("Adur District Council" in councils)
+
+    def test_dry_run(self):
+        data_file = pathlib.Path(__file__).parent.resolve() / "data" / "volunteers.csv"
+
+        self.assertEquals(User.objects.count(), 0)
+        self.assertEquals(Marker.objects.count(), 0)
+        self.assertEquals(Assigned.objects.count(), 0)
+        self.call_command(
+            "import_volunteers",
+            session="Default",
+            file=data_file,
+            add_users=True,
+            make_assignments=True,
+            dry_run=True,
+        )
+        self.assertEquals(User.objects.count(), 0)
+        self.assertEquals(Marker.objects.count(), 0)
+        self.assertEquals(Assigned.objects.count(), 0)
 
     def test_multi_councils(self):
         data_file = (
@@ -396,3 +418,189 @@ class AssignVolunteers(BaseCommandTestCase):
         self.assertTrue("Aberdeenshire Council" not in councils)
         self.assertTrue("Adur District Council" not in councils)
         self.assertTrue("Aberdeen City Council" in councils)
+
+    def test_assignment_limits_in_file(self):
+        data_file = (
+            pathlib.Path(__file__).parent.resolve()
+            / "data"
+            / "volunteers_with_limit.csv"
+        )
+        self.add_extra_councils()
+
+        self.assertEquals(Assigned.objects.count(), 0)
+        self.call_command(
+            "import_volunteers",
+            session="Default",
+            file=data_file,
+            add_users=True,
+            make_assignments=True,
+            assignment_count_in_data=True,
+        )
+        self.assertEquals(User.objects.count(), 1)
+        self.assertEquals(Marker.objects.count(), 1)
+        self.assertEquals(Assigned.objects.count(), 3)
+        self.assertEquals(
+            Assigned.objects.filter(
+                marking_session__label="Default", section__title="Transport"
+            ).count(),
+            3,
+        )
+
+    def test_council_preferences(self):
+        data_file = (
+            pathlib.Path(__file__).parent.resolve()
+            / "data"
+            / "volunteers_with_council_restriction.csv"
+        )
+        self.add_extra_councils()
+
+        self.assertEquals(Assigned.objects.count(), 0)
+        self.call_command(
+            "import_volunteers",
+            session="Default",
+            file=data_file,
+            add_users=True,
+            make_assignments=True,
+            preferred_councils=True,
+        )
+        self.assertEquals(User.objects.count(), 1)
+        self.assertEquals(Marker.objects.count(), 1)
+        self.assertEquals(Assigned.objects.count(), 6)
+        self.assertEquals(
+            Assigned.objects.filter(
+                marking_session__label="Default", section__title="Transport"
+            ).count(),
+            6,
+        )
+
+        councils = [a.authority.name for a in Assigned.objects.all()]
+        self.assertTrue("Aberdeen City Council" not in councils)
+
+        # need to remove them all as won't assign to people with existing assignments
+        Assigned.objects.all().delete()
+
+        ob = PublicAuthority.objects.get(unique_id="E90001")
+        ob.type = "LBO"
+        ob.save()
+
+        PublicAuthority.objects.filter(
+            unique_id__in=("E90004", "E90005", "E90006", "E90007")
+        ).delete()
+
+        self.call_command(
+            "import_volunteers",
+            session="Default",
+            file=data_file,
+            add_users=True,
+            make_assignments=True,
+            preferred_councils=True,
+        )
+        self.assertEquals(User.objects.count(), 1)
+        self.assertEquals(Marker.objects.count(), 1)
+        self.assertEquals(Assigned.objects.count(), 6)
+        self.assertEquals(
+            Assigned.objects.filter(
+                marking_session__label="Default", section__title="Transport"
+            ).count(),
+            6,
+        )
+
+        councils = [a.authority.name for a in Assigned.objects.all()]
+        self.assertTrue("East Borsetshire" in councils)
+        self.assertTrue("Aberdeen City Council" in councils)
+
+    def test_audit_assignments(self):
+        data_file = pathlib.Path(__file__).parent.resolve() / "data" / "volunteers.csv"
+
+        self.assertEquals(User.objects.count(), 0)
+        self.assertEquals(Marker.objects.count(), 0)
+        self.assertEquals(Assigned.objects.count(), 0)
+        self.call_command(
+            "import_volunteers",
+            session="Default",
+            response_type="Audit",
+            file=data_file,
+            add_users=True,
+            make_assignments=True,
+        )
+        self.assertEquals(User.objects.count(), 1)
+        self.assertEquals(Marker.objects.count(), 1)
+        self.assertEquals(Assigned.objects.count(), 2)
+        self.assertEquals(
+            Assigned.objects.filter(
+                marking_session__label="Default",
+                section__title="Transport",
+                response_type__type="Audit",
+            ).count(),
+            2,
+        )
+
+        u = User.objects.all()[0]
+        m = Marker.objects.all()[0]
+        self.assertEquals(u.username, "first_last@example.org")
+        self.assertEquals(m.response_type.type, "Audit")
+
+        councils = [a.authority.name for a in Assigned.objects.all()]
+        self.assertTrue("Aberdeenshire Council" not in councils)
+        self.assertTrue("Aberdeen City Council" in councils)
+        self.assertTrue("Adur District Council" in councils)
+
+    def test_audit_assignments_avoids_previous_assignments(self):
+        data_file = pathlib.Path(__file__).parent.resolve() / "data" / "volunteers.csv"
+
+        self.call_command(
+            "import_volunteers",
+            session="Default",
+            file=data_file,
+            add_users=True,
+            make_assignments=True,
+        )
+
+        Assigned.objects.all().delete()
+
+        u = User.objects.get(username="first_last@example.org")
+        s = Section.objects.get(title="Transport", marking_session__label="Default")
+        a = PublicAuthority.objects.get(name="Aberdeen City Council")
+        rt = ResponseType.objects.get(type="First Mark")
+        ms = MarkingSession.objects.get(label="Default")
+
+        Assigned.objects.create(
+            user=u,
+            section=s,
+            authority=a,
+            response_type=rt,
+            marking_session=ms,
+        )
+
+        self.call_command(
+            "import_volunteers",
+            session="Default",
+            response_type="Audit",
+            file=data_file,
+            add_users=True,
+            make_assignments=True,
+        )
+        self.assertEquals(User.objects.count(), 1)
+        self.assertEquals(Marker.objects.count(), 1)
+        self.assertEquals(Assigned.objects.count(), 2)
+        self.assertEquals(
+            Assigned.objects.filter(
+                marking_session__label="Default",
+                section__title="Transport",
+                response_type__type="Audit",
+            ).count(),
+            1,
+        )
+
+        u = User.objects.all()[0]
+        m = Marker.objects.all()[0]
+        self.assertEquals(u.username, "first_last@example.org")
+        self.assertEquals(m.response_type.type, "Audit")
+
+        councils = [
+            a.authority.name
+            for a in Assigned.objects.filter(response_type__type="Audit")
+        ]
+        self.assertTrue("Aberdeenshire Council" not in councils)
+        self.assertTrue("Aberdeen City Council" not in councils)
+        self.assertTrue("Adur District Council" in councils)


### PR DESCRIPTION
This updates the volunteer import script to make it yet more flexible.

Adds the following:

* a `--dry_run` option which runs everything inside a transaction and then rolls it back so you can get the full report of what it would do without changing the DB. Mostly to allow checking if it's going to assign everything required
* a `--council_restrictions` option which indicates there is a column in the import data with details of council restrictions for some volunteers
* a `--section_count_in_data` which indicates that the number of councils to assign to volunteers is contained in a column in the import data.

Fixes #207 